### PR TITLE
Fix bug in media query for splash height for desktop

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -137,7 +137,7 @@ main header p:last-of-type {
   .splash p { padding-top: 0; }
 }
 
-@media only screen and (min-width: 1120px) {    /* Desktop */
+@media only screen and (min-width: 1200px) {    /* Desktop */
   .splash { height: 525px; }
 }
 


### PR DESCRIPTION
Fix bug in media query for .splash: change height: 1120px to 1200px